### PR TITLE
Add counterfactual training

### DIFF
--- a/algo/config/config.py
+++ b/algo/config/config.py
@@ -52,12 +52,12 @@ class Config:
     deterministic: bool = True
 
     # Color augmentation
-    use_color_relabeling: bool = False
+    use_color_relabeling: bool = True
     augmentation_variants: int = 1  # Number of augmented versions per original example
     preserve_background: bool = True  # Keep background color (0) unchanged
 
     # Counterfactual augmentation
-    enable_counterfactuals: bool = False
+    enable_counterfactuals: bool = True
     counterfactual_transform: str = (
         "rotate_90"  # "rotate_90", "rotate_180", "rotate_270", "reflect_h", "reflect_v"
     )

--- a/algo/config/config.py
+++ b/algo/config/config.py
@@ -56,6 +56,12 @@ class Config:
     augmentation_variants: int = 1  # Number of augmented versions per original example
     preserve_background: bool = True  # Keep background color (0) unchanged
 
+    # Counterfactual augmentation
+    enable_counterfactuals: bool = False
+    counterfactual_transform: str = (
+        "rotate_90"  # "rotate_90", "rotate_180", "rotate_270", "reflect_h", "reflect_v"
+    )
+
     # Color palette (ARC official 10 colors)
     color_palette: List[List[float]] = None
 

--- a/algo/data/dataset.py
+++ b/algo/data/dataset.py
@@ -4,6 +4,8 @@ from pathlib import Path
 from typing import Dict, List, Any, Tuple
 import json
 import itertools
+import copy
+import numpy as np
 from ..config import Config
 from .preprocessing import preprocess_example_image, preprocess_target_image
 from .augmentation import generate_augmented_examples
@@ -11,7 +13,7 @@ from .augmentation import generate_augmented_examples
 
 def custom_collate_fn(batch):
     """
-    Custom collate function for ARC dataset with full tensor batching.
+    Custom collate function for ARC dataset with simplified structure.
 
     Args:
         batch: List of samples from the dataset
@@ -20,74 +22,72 @@ def custom_collate_fn(batch):
         Collated batch with proper tensor structure
     """
     batch_size = len(batch)
-    # Find the maximum number of training examples in this batch
-    max_train = max(len(sample["training_targets"]) for sample in batch)
 
     # Pre-allocate tensors
     rule_latent_inputs = torch.zeros(
         [batch_size, 2, 2, 3, 64, 64]
     )  # 2 examples, 2 images each
-    all_train_inputs = torch.zeros([batch_size, max_train, 1, 30, 30])
-    all_train_outputs = torch.zeros([batch_size, max_train, 1, 30, 30])
     test_inputs = torch.zeros([batch_size, 1, 30, 30])
     test_outputs = torch.zeros([batch_size, 1, 30, 30])
     holdout_inputs = torch.zeros([batch_size, 1, 30, 30])
     holdout_outputs = torch.zeros([batch_size, 1, 30, 30])
-    num_train = torch.zeros([batch_size], dtype=torch.long)
     has_holdout = torch.zeros([batch_size], dtype=torch.bool)
 
-    # Collect combination info for each sample
-    combination_info_list = []
+    # Collect metadata for each sample
+    task_indices = []
+    task_ids = []
+    is_counterfactual = []
+    combination_indices = []
+    pair_indices = []
+    total_combinations = []
 
     # Fill with real data
     for i, sample in enumerate(batch):
         # Rule latent inputs (2 examples for ResNet)
-        rule_latent_inputs[i, 0, 0] = sample["rule_latent_inputs"][0]["input"].squeeze(
-            0
-        )  # [3, 64, 64]
-        rule_latent_inputs[i, 0, 1] = sample["rule_latent_inputs"][0]["output"].squeeze(
-            0
-        )
-        rule_latent_inputs[i, 1, 0] = sample["rule_latent_inputs"][1]["input"].squeeze(
-            0
-        )
-        rule_latent_inputs[i, 1, 1] = sample["rule_latent_inputs"][1]["output"].squeeze(
-            0
-        )
+        rule_latent_inputs[i, 0, 0] = sample["rule_latent_examples"][0][
+            "input"
+        ].squeeze(0)  # [3, 64, 64]
+        rule_latent_inputs[i, 0, 1] = sample["rule_latent_examples"][0][
+            "output"
+        ].squeeze(0)
+        rule_latent_inputs[i, 1, 0] = sample["rule_latent_examples"][1][
+            "input"
+        ].squeeze(0)
+        rule_latent_inputs[i, 1, 1] = sample["rule_latent_examples"][1][
+            "output"
+        ].squeeze(0)
 
-        # Training targets
-        targets = sample["training_targets"]
-        num_train[i] = len(targets)
+        # Test example
+        test_inputs[i] = sample["test_example"]["input"].squeeze(0)
+        test_outputs[i] = sample["test_example"]["output"].squeeze(0)
 
-        for j, target in enumerate(targets):
-            all_train_inputs[i, j] = target["input"].squeeze(0)  # [1, 30, 30]
-            all_train_outputs[i, j] = target["output"].squeeze(0)
-
-        # Test target (last in training_targets)
-        test_inputs[i] = targets[-1]["input"].squeeze(0)
-        test_outputs[i] = targets[-1]["output"].squeeze(0)
-
-        # Holdout target (if available)
-        if sample["holdout_target"] is not None:
-            holdout_inputs[i] = sample["holdout_target"]["input"].squeeze(0)
-            holdout_outputs[i] = sample["holdout_target"]["output"].squeeze(0)
+        # Holdout example (if available)
+        if sample["holdout_example"] is not None:
+            holdout_inputs[i] = sample["holdout_example"]["input"].squeeze(0)
+            holdout_outputs[i] = sample["holdout_example"]["output"].squeeze(0)
             has_holdout[i] = True
 
-        # Collect combination info
-        if "combination_info" in sample:
-            combination_info_list.append(sample["combination_info"])
+        # Collect metadata
+        task_indices.append(sample["task_idx"])
+        task_ids.append(sample["task_id"])
+        is_counterfactual.append(sample["is_counterfactual"])
+        combination_indices.append(sample["combination_idx"])
+        pair_indices.append(sample["pair_indices"])
+        total_combinations.append(sample["total_combinations"])
 
     return {
         "rule_latent_inputs": rule_latent_inputs,  # [B, 2, 2, 3, 64, 64]
-        "all_train_inputs": all_train_inputs,  # [B, max_train, 1, 30, 30]
-        "all_train_outputs": all_train_outputs,  # [B, max_train, 1, 30, 30]
         "test_inputs": test_inputs,  # [B, 1, 30, 30]
         "test_outputs": test_outputs,  # [B, 1, 30, 30]
         "holdout_inputs": holdout_inputs,  # [B, 1, 30, 30]
         "holdout_outputs": holdout_outputs,  # [B, 1, 30, 30]
-        "num_train": num_train,  # [B]
         "has_holdout": has_holdout,  # [B]
-        "combination_info": combination_info_list,  # [B] list of combination info dicts
+        "task_indices": task_indices,  # [B] list of task indices
+        "task_ids": task_ids,  # [B] list of task IDs
+        "is_counterfactual": is_counterfactual,  # [B] list of counterfactual flags
+        "combination_indices": combination_indices,  # [B] list of combination indices
+        "pair_indices": pair_indices,  # [B] list of pair indices
+        "total_combinations": total_combinations,  # [B] list of total combinations per task
     }
 
 
@@ -155,8 +155,11 @@ class ARCDataset(Dataset):
         combinations = []
 
         for task_idx, task in enumerate(self.tasks):
-            # Get original examples
+            # Get original examples and preserve them
             original_examples = task["train"]
+            task["original_train"] = copy.deepcopy(
+                original_examples
+            )  # Preserve original
 
             # Generate augmented examples if enabled
             if self.config.use_color_relabeling:
@@ -178,6 +181,31 @@ class ARCDataset(Dataset):
                 task_combinations = list(
                     itertools.combinations(range(total_examples), 2)
                 )
+
+                # NEW: Add counterfactual combinations if enabled
+                if self.config.enable_counterfactuals:
+                    # Create counterfactual examples for this task
+                    self._create_counterfactual_examples(task)
+
+                    # Add counterfactual combinations
+                    # Mark them with a flag to indicate they're counterfactual
+                    counterfactual_combinations = [
+                        (combo[0], combo[1], True) for combo in task_combinations
+                    ]
+                    # Mark original combinations as not counterfactual
+                    original_combinations = [
+                        (combo[0], combo[1], False) for combo in task_combinations
+                    ]
+                    # Combine both
+                    task_combinations = (
+                        original_combinations + counterfactual_combinations
+                    )
+                else:
+                    # Original behavior - mark all as not counterfactual
+                    task_combinations = [
+                        (combo[0], combo[1], False) for combo in task_combinations
+                    ]
+
                 combinations.append(task_combinations)
             else:
                 combinations.append([])
@@ -221,87 +249,398 @@ class ARCDataset(Dataset):
         """Return total number of combinations across all valid tasks."""
         return len(self.combination_mapping)
 
-    def _preprocess_example(self, example: Dict[str, Any]) -> Dict[str, torch.Tensor]:
+    def _preprocess_example(
+        self, example: Dict[str, Any], apply_counterfactual: bool = False
+    ) -> Dict[str, torch.Tensor]:
         """Preprocess a single example (input/output pair)."""
         input_tensor = preprocess_example_image(example["input"], self.config)
         output_tensor = preprocess_example_image(example["output"], self.config)
+
+        # Apply counterfactual transformation after preprocessing if requested
+        if apply_counterfactual:
+            output_tensor = self._apply_counterfactual_transform(output_tensor)
+
         return {
             "input": input_tensor.unsqueeze(0),  # Add batch dimension [1, C, H, W]
             "output": output_tensor.unsqueeze(0),  # Add batch dimension [1, C, H, W]
         }
 
-    def _preprocess_target(self, example: Dict[str, Any]) -> Dict[str, torch.Tensor]:
+    def _preprocess_target(
+        self, example: Dict[str, Any], apply_counterfactual: bool = False
+    ) -> Dict[str, torch.Tensor]:
         """Preprocess a single target example (input/output pair)."""
         input_tensor = preprocess_target_image(example["input"], self.config)
         output_tensor = preprocess_target_image(example["output"], self.config)
+
+        # Apply counterfactual transformation after preprocessing if requested
+        if apply_counterfactual:
+            output_tensor = self._apply_counterfactual_transform(output_tensor)
+
         return {
             "input": input_tensor.unsqueeze(0),  # Add batch dimension [1, C, H, W]
             "output": output_tensor.unsqueeze(0),  # Add batch dimension [1, C, H, W]
         }
 
-    def __getitem__(self, idx: int) -> Dict[str, Any]:
-        """
-        Get sample by index using full combination mapping.
+    def _apply_counterfactual_transform(self, image):
+        """Apply counterfactual transformation to an image."""
+        if self.config.counterfactual_transform == "rotate_90":
+            return self._rotate_90(image)
+        elif self.config.counterfactual_transform == "rotate_180":
+            return self._rotate_180(image)
+        elif self.config.counterfactual_transform == "rotate_270":
+            return self._rotate_270(image)
+        elif self.config.counterfactual_transform == "reflect_h":
+            return self._reflect_horizontal(image)
+        elif self.config.counterfactual_transform == "reflect_v":
+            return self._reflect_vertical(image)
+        else:
+            raise ValueError(
+                f"Unknown counterfactual transform: {self.config.counterfactual_transform}"
+            )
 
-        Args:
-            idx: Linear index into all combinations across all tasks
+    def _rotate_90(self, image):
+        """Rotate image by 90 degrees clockwise."""
+        if isinstance(image, torch.Tensor):
+            return torch.rot90(image, k=1, dims=[-2, -1])
+        else:  # numpy array
+            return np.rot90(image, k=1)
 
-        Returns:
-            Dictionary containing:
-                - rule_latent_inputs: List of 2 examples for rule latent creation
-                - training_targets: List of all examples for training
-                - holdout_target: Holdout example (if holdout=True)
-                - combination_info: Information about current combination
+    def _rotate_180(self, image):
+        """Rotate image by 180 degrees."""
+        if isinstance(image, torch.Tensor):
+            return torch.rot90(image, k=2, dims=[-2, -1])
+        else:  # numpy array
+            return np.rot90(image, k=2)
+
+    def _rotate_270(self, image):
+        """Rotate image by 270 degrees clockwise (90 degrees counterclockwise)."""
+        if isinstance(image, torch.Tensor):
+            return torch.rot90(image, k=3, dims=[-2, -1])
+        else:  # numpy array
+            return np.rot90(image, k=3)
+
+    def _reflect_horizontal(self, image):
+        """Reflect image horizontally."""
+        if isinstance(image, torch.Tensor):
+            return torch.flip(image, dims=[-1])
+        else:  # numpy array
+            return np.fliplr(image)
+
+    def _reflect_vertical(self, image):
+        """Reflect image vertically."""
+        if isinstance(image, torch.Tensor):
+            return torch.flip(image, dims=[-2])
+        else:  # numpy array
+            return np.flipud(image)
+
+    def _create_counterfactual_examples(self, task):
         """
-        # Get task and combination indices from mapping
+        Pre-generate counterfactual versions of all examples in a task.
+        They are transformed after preprocessing to preserve the post padding shape.
+        """
+        # Create counterfactual training examples
+        counterfactual_train = []
+        for example in task["train"]:
+            cf_example = copy.deepcopy(example)
+            cf_example["input"] = example["input"]  # Keep input the same
+            # Don't transform output here - we'll do it after preprocessing
+            counterfactual_train.append(cf_example)
+
+        # Create counterfactual test examples
+        counterfactual_test = []
+        for example in task["test"]:
+            cf_example = copy.deepcopy(example)
+            cf_example["input"] = example["input"]  # Keep input the same
+            # Don't transform output here - we'll do it after preprocessing
+            counterfactual_test.append(cf_example)
+
+        # Store counterfactual examples in task
+        task["counterfactual_train"] = counterfactual_train
+        task["counterfactual_test"] = counterfactual_test
+
+        # If color relabeling is enabled, also create counterfactual augmented examples
+        if self.config.use_color_relabeling and "augmented_train" in task:
+            counterfactual_augmented = []
+            for example in task["augmented_train"]:
+                cf_example = copy.deepcopy(example)
+                cf_example["input"] = example["input"]  # Keep input the same
+                # Don't transform output here - we'll do it after preprocessing
+                counterfactual_augmented.append(cf_example)
+            task["counterfactual_augmented_train"] = counterfactual_augmented
+
+    def _get_combination_info(self, idx: int) -> Tuple[int, int, Tuple[int, int], bool]:
+        """Get task index, combination index, pair indices, and counterfactual flag."""
         task_idx, combination_idx = self.combination_mapping[idx]
-        task = self.tasks[task_idx]
         task_combinations = self.combinations[task_idx]
-
-        # Get the specific combination
         pair_indices = task_combinations[combination_idx]
 
-        # Get all available examples (original + augmented)
+        # Check if this is a counterfactual combination
+        if len(pair_indices) == 3:  # (i, j, is_counterfactual)
+            i, j, is_counterfactual = pair_indices
+        else:
+            i, j = pair_indices
+            is_counterfactual = False
+
+        return task_idx, combination_idx, (i, j), is_counterfactual
+
+    def _get_all_examples(
+        self, task: Dict[str, Any], is_counterfactual: bool
+    ) -> List[Dict[str, Any]]:
+        """Get all available examples (original + augmented + counterfactual if applicable)."""
         all_examples = task["train"]
+
         if self.config.use_color_relabeling and "augmented_train" in task:
             all_examples = task["train"] + task["augmented_train"]
 
-        # Rule latent inputs (2 examples) - preprocess for ResNet
-        rule_latent_inputs = [
-            self._preprocess_example(all_examples[pair_indices[0]]),
-            self._preprocess_example(all_examples[pair_indices[1]]),
-        ]
+        if is_counterfactual:
+            all_examples = all_examples + task["counterfactual_train"]
+            if (
+                self.config.use_color_relabeling
+                and "counterfactual_augmented_train" in task
+            ):
+                all_examples = all_examples + task["counterfactual_augmented_train"]
 
-        # Holdout target (if enabled and available)
-        holdout_target = None
-        train_examples_to_use = all_examples  # Use all examples (original + augmented)
+        return all_examples
+
+    def _create_rule_latent_inputs(
+        self,
+        all_examples: List[Dict[str, Any]],
+        i: int,
+        j: int,
+        is_counterfactual: bool,
+    ) -> List[Dict[str, torch.Tensor]]:
+        """Create rule latent inputs from examples i and j."""
+        if is_counterfactual:
+            # For counterfactual combinations, create counterfactual versions
+            ex1 = copy.deepcopy(all_examples[i])
+            ex2 = copy.deepcopy(all_examples[j])
+
+            # Preprocess with counterfactual transformation
+            ex1_processed = self._preprocess_example(ex1, apply_counterfactual=True)
+            ex2_processed = self._preprocess_example(ex2, apply_counterfactual=True)
+
+            return [ex1_processed, ex2_processed]
+        else:
+            # For non-counterfactual combinations, use original examples
+            return [
+                self._preprocess_example(all_examples[i]),
+                self._preprocess_example(all_examples[j]),
+            ]
+
+    def _create_training_targets(
+        self,
+        task: Dict[str, Any],
+        is_counterfactual: bool,
+        train_examples_to_use: List[Dict[str, Any]] = None,
+    ) -> List[Dict[str, torch.Tensor]]:
+        """Create training targets based on whether this is a counterfactual combination."""
+        if is_counterfactual:
+            # Use counterfactual training examples (with transformations applied)
+            training_targets = []
+
+            # Add counterfactual training examples (apply transformation after preprocessing)
+            for train_example in task["counterfactual_train"]:
+                training_targets.append(
+                    self._preprocess_target(train_example, apply_counterfactual=True)
+                )
+
+            # Add counterfactual augmented examples if available
+            if (
+                self.config.use_color_relabeling
+                and "counterfactual_augmented_train" in task
+            ):
+                for train_example in task["counterfactual_augmented_train"]:
+                    training_targets.append(
+                        self._preprocess_target(
+                            train_example, apply_counterfactual=True
+                        )
+                    )
+
+            # Add test examples (both original and counterfactual)
+            for test_example in task["test"]:
+                training_targets.append(self._preprocess_target(test_example))
+            for test_example in task["counterfactual_test"]:
+                training_targets.append(
+                    self._preprocess_target(test_example, apply_counterfactual=True)
+                )
+
+            return training_targets
+        else:
+            # Use original training examples (existing logic)
+            training_targets = []
+            if train_examples_to_use is None:
+                train_examples_to_use = task["train"]
+            for train_example in train_examples_to_use:
+                training_targets.append(self._preprocess_target(train_example))
+            for test_example in task["test"]:
+                training_targets.append(self._preprocess_target(test_example))
+            return training_targets
+
+    def _create_holdout_target(
+        self, task: Dict[str, Any], is_counterfactual: bool
+    ) -> Dict[str, torch.Tensor]:
+        """Create holdout target if enabled and available."""
+        if not self.holdout or len(task["train"]) <= 2:
+            return None
+
+        if is_counterfactual and len(task["counterfactual_train"]) > 2:
+            return self._preprocess_target(
+                task["counterfactual_train"][-1], apply_counterfactual=True
+            )
+        else:
+            return self._preprocess_target(task["train"][-1])
+
+    def _get_train_examples_to_use(self, task: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """Get training examples to use (excluding holdout if applicable)."""
         if self.holdout and len(task["train"]) > 2:
-            # For holdout, use the last original train example (not augmented)
-            holdout_target = self._preprocess_target(
-                task["train"][-1]
-            )  # Last original train example
             # Remove holdout from original train examples to use
             train_examples_to_use = task["train"][:-1]
             # Add augmented examples if available
             if self.config.use_color_relabeling and "augmented_train" in task:
                 train_examples_to_use = train_examples_to_use + task["augmented_train"]
+            return train_examples_to_use
+        else:
+            return task["train"]
 
-        # Training targets (all available examples) - preprocess appropriately
-        training_targets = []
-        for train_example in train_examples_to_use:
-            training_targets.append(self._preprocess_target(train_example))
-        for test_example in task["test"]:
-            training_targets.append(self._preprocess_target(test_example))
+    def __getitem__(self, idx: int) -> Dict[str, Any]:
+        """
+        Get sample by index - simplified structure.
+
+        Returns only what's needed for a single combination:
+        - 2 examples for rule latent creation
+        - 1 test example for evaluation
+        - Optional holdout
+        """
+        # Get combination information
+        task_idx, combination_idx, (i, j), is_counterfactual = (
+            self._get_combination_info(idx)
+        )
+        task = self.tasks[task_idx]
+
+        # Get all available examples
+        all_examples = self._get_all_examples(task, is_counterfactual)
+
+        # Create rule latent inputs (2 examples for encoder)
+        rule_latent_inputs = self._create_rule_latent_inputs(
+            all_examples, i, j, is_counterfactual
+        )
+
+        # Create test example
+        test_example = self._get_test_example(task, is_counterfactual)
+
+        # Create holdout example (if available)
+        holdout_example = self._get_holdout_example(task, is_counterfactual)
 
         return {
-            "rule_latent_inputs": rule_latent_inputs,
-            "training_targets": training_targets,
-            "holdout_target": holdout_target,
-            "combination_info": {
-                "task_idx": task_idx,
-                "task_id": task["task_id"],
-                "combination_idx": combination_idx,
-                "pair_indices": pair_indices,
-                "total_combinations": len(task_combinations),
-            },
+            # Core data - only what's needed for this combination
+            "rule_latent_examples": rule_latent_inputs,  # 2 examples for encoder
+            "test_example": test_example,  # Single test example
+            "holdout_example": holdout_example,  # Optional holdout
+            # Top-level metadata
+            "task_idx": task_idx,  # Top-level task index
+            "task_id": task["task_id"],  # Top-level task ID
+            "is_counterfactual": is_counterfactual,  # Top-level flag
+            "combination_idx": combination_idx,  # Top-level combination index
+            "pair_indices": (i, j),  # Top-level pair indices
+            "total_combinations": len(self.combinations[task_idx]),  # Top-level count
+        }
+
+    def _get_test_example(
+        self, task: Dict[str, Any], is_counterfactual: bool
+    ) -> Dict[str, torch.Tensor]:
+        """Get single test example."""
+        if is_counterfactual and task.get("counterfactual_test"):
+            return self._preprocess_target(
+                task["counterfactual_test"][0], apply_counterfactual=True
+            )
+        else:
+            return self._preprocess_target(task["test"][0])
+
+    def _get_holdout_example(
+        self, task: Dict[str, Any], is_counterfactual: bool
+    ) -> Dict[str, torch.Tensor]:
+        """Get holdout example if available."""
+        if not self.holdout or len(task["train"]) <= 2:
+            return None
+
+        if is_counterfactual and len(task.get("counterfactual_train", [])) > 2:
+            return self._preprocess_target(
+                task["counterfactual_train"][-1], apply_counterfactual=True
+            )
+        else:
+            return self._preprocess_target(task["train"][-1])
+
+    def get_all_training_examples_for_task(
+        self, task_idx: int
+    ) -> List[Dict[str, torch.Tensor]]:
+        """Get all training examples for a specific task."""
+        task = self.tasks[task_idx]
+        training_examples = []
+
+        # Get original training examples
+        for example in task["train"]:
+            training_examples.append(self._preprocess_target(example))
+
+        # Add augmented examples if available
+        if self.config.use_color_relabeling and "augmented_train" in task:
+            for example in task["augmented_train"]:
+                training_examples.append(self._preprocess_target(example))
+
+        # Add counterfactual examples if available
+        if self.config.enable_counterfactuals and "counterfactual_train" in task:
+            for example in task["counterfactual_train"]:
+                training_examples.append(
+                    self._preprocess_target(example, apply_counterfactual=True)
+                )
+
+        return training_examples
+
+    def get_task_combinations(self, task_idx: int) -> Dict[str, List[Dict[str, Any]]]:
+        """Get all combinations for a specific task."""
+        if task_idx not in self.valid_tasks:
+            raise ValueError(f"Task {task_idx} not valid")
+
+        task_combinations = self.combinations[task_idx]
+
+        regular_combinations = []
+        counterfactual_combinations = []
+
+        for combo_idx, combo in enumerate(task_combinations):
+            if len(combo) == 3:
+                i, j, is_counterfactual = combo
+            else:
+                i, j = combo
+                is_counterfactual = False
+
+            # Get the data for this combination
+            linear_idx = None
+            for idx, (t_idx, c_idx) in enumerate(self.combination_mapping):
+                if t_idx == task_idx and c_idx == combo_idx:
+                    linear_idx = idx
+                    break
+
+            if linear_idx is not None:
+                combination_data = self[linear_idx]
+
+                clean_data = {
+                    "combination_idx": combo_idx,
+                    "pair_indices": (i, j),
+                    "is_counterfactual": is_counterfactual,
+                    "rule_latent_examples": combination_data["rule_latent_examples"],
+                    "test_example": combination_data["test_example"],
+                    "holdout_example": combination_data["holdout_example"],
+                    "task_id": combination_data["task_id"],
+                    "task_idx": combination_data["task_idx"],
+                    "total_combinations": combination_data["total_combinations"],
+                }
+
+                if is_counterfactual:
+                    counterfactual_combinations.append(clean_data)
+                else:
+                    regular_combinations.append(clean_data)
+
+        return {
+            "regular": regular_combinations,
+            "counterfactual": counterfactual_combinations,
+            "all": regular_combinations + counterfactual_combinations,
         }

--- a/algo/data/preprocessing.py
+++ b/algo/data/preprocessing.py
@@ -35,6 +35,7 @@ def preprocess_example_image(image_data: np.ndarray, config: Config) -> torch.Te
         Preprocessed RGB tensor [3, 64, 64] normalized to [-1, 1]
     """
     # Convert to tensor and ensure float32
+    image_data = image_data.copy()
     img_tensor = torch.tensor(image_data, dtype=torch.float32)
 
     # Pad or crop to 30x30
@@ -86,6 +87,7 @@ def preprocess_target_image(image_data: np.ndarray, config: Config) -> torch.Ten
         Preprocessed grayscale tensor [1, 30, 30]
     """
     # Convert to tensor and ensure float32
+    image_data = image_data.copy()
     img_tensor = torch.tensor(image_data, dtype=torch.float32)
 
     # Pad or crop to 30x30

--- a/algo/data/task_subset.py
+++ b/algo/data/task_subset.py
@@ -81,6 +81,11 @@ class TaskSubset(ARCDataset):
             all_examples, i, j, is_counterfactual
         )
 
+        # Create rule latent targets using the base class helper
+        rule_latent_targets = self._create_rule_latent_targets(
+            all_examples, i, j, is_counterfactual
+        )
+
         # Create test example using the base class helper
         test_example = self._get_test_example(task, is_counterfactual)
 
@@ -89,7 +94,8 @@ class TaskSubset(ARCDataset):
 
         return {
             # Core data - only what's needed for this combination
-            "rule_latent_examples": rule_latent_inputs,  # 2 examples for encoder
+            "rule_latent_examples": rule_latent_inputs,  # 2 examples for encoder (ResNet format)
+            "rule_latent_targets": rule_latent_targets,  # 2 examples for decoder (ARC format)
             "test_example": test_example,  # Single test example
             "holdout_example": holdout_example,  # Optional holdout
             # Top-level metadata

--- a/algo/training/losses.py
+++ b/algo/training/losses.py
@@ -18,8 +18,8 @@ def calculate_classification_loss(
         Tuple of (total_loss, loss_components)
     """
     # Flatten spatial dimensions for cross-entropy
-    logits_flat = logits.view(logits.size(0), 10, -1)  # [B, 10, 900]
-    target_flat = target.view(target.size(0), -1)  # [B, 900]
+    logits_flat = logits.reshape(logits.size(0), 10, -1)  # [B, 10, 900]
+    target_flat = target.reshape(target.size(0), -1)  # [B, 900]
 
     # Cross-entropy loss
     cross_entropy_loss = F.cross_entropy(logits_flat, target_flat.long())

--- a/algo/training/trainer.py
+++ b/algo/training/trainer.py
@@ -141,93 +141,100 @@ class ARCTrainer:
 
         for batch_idx, batch in enumerate(pbar):
             # Move batch to device
-            rule_latent_inputs = batch["rule_latent_inputs"].to(self.device)
-            holdout_inputs = batch["holdout_inputs"].to(self.device)
-            holdout_outputs = batch["holdout_outputs"].to(self.device)
-            has_holdout = batch["has_holdout"].to(self.device)
+            rule_latent_inputs = batch["rule_latent_inputs"].to(
+                self.device
+            )  # [B, 2, 2, 3, 64, 64]
+            test_inputs = batch["test_inputs"].to(self.device)  # [B, 1, 30, 30]
+            test_outputs = batch["test_outputs"].to(self.device)  # [B, 1, 30, 30]
+            holdout_inputs = batch["holdout_inputs"].to(self.device)  # [B, 1, 30, 30]
+            holdout_outputs = batch["holdout_outputs"].to(self.device)  # [B, 1, 30, 30]
+            has_holdout = batch["has_holdout"].to(self.device)  # [B]
+            raw_rule_latent_targets = batch[
+                "raw_rule_latent_targets"
+            ]  # [B] list of raw targets (ARC format)
 
-            # Get task indices for this batch
-            task_indices = batch["task_indices"]
-
-            # Get all training examples for each task in the batch
             batch_size = rule_latent_inputs.size(0)
-            max_train = 0
-            all_train_inputs_list = []
-            all_train_outputs_list = []
-            num_train_list = []
 
-            for i in range(batch_size):
-                task_idx = task_indices[i]  # Already an integer from the list
-                training_examples = self.dataset.get_all_training_examples_for_task(
-                    task_idx
-                )
+            # Reshape rule latent inputs for encoder: [B, 4, 3, 64, 64] where 4 = 2 examples * 2 images each
+            rule_inputs_batch = rule_latent_inputs.view(batch_size, 4, 3, 64, 64)
 
-                # Extract inputs and outputs
-                train_inputs = [
-                    ex["input"].squeeze(0) for ex in training_examples
-                ]  # Remove batch dim
-                train_outputs = [ex["output"].squeeze(0) for ex in training_examples]
+            # Split into the 4 components the encoder expects
+            example1_inputs = rule_inputs_batch[:, 0]  # [B, 3, 64, 64]
+            example1_outputs = rule_inputs_batch[:, 1]  # [B, 3, 64, 64]
+            example2_inputs = rule_inputs_batch[:, 2]  # [B, 3, 64, 64]
+            example2_outputs = rule_inputs_batch[:, 3]  # [B, 3, 64, 64]
 
-                max_train = max(max_train, len(train_inputs))
-                all_train_inputs_list.append(train_inputs)
-                all_train_outputs_list.append(train_outputs)
-                num_train_list.append(len(train_inputs))
+            # Run encoder on entire batch at once
+            rule_latents = self.model.encoder(
+                example1_inputs, example1_outputs, example2_inputs, example2_outputs
+            )  # [B, 128]
 
-            # Pad all training inputs to consistent shape
-            all_train_inputs = torch.zeros([batch_size, max_train, 1, 30, 30]).to(
-                self.device
-            )
-            all_train_outputs = torch.zeros([batch_size, max_train, 1, 30, 30]).to(
-                self.device
-            )
-
-            for i, (train_inputs, train_outputs) in enumerate(
-                zip(all_train_inputs_list, all_train_outputs_list)
-            ):
-                for j, (train_input, train_output) in enumerate(
-                    zip(train_inputs, train_outputs)
-                ):
-                    all_train_inputs[i, j] = train_input
-                    all_train_outputs[i, j] = train_output
-
-            num_train = torch.tensor(num_train_list, dtype=torch.long).to(self.device)
-
-            # Forward pass with batched rule latent training
-            outputs = self.model.forward_rule_latent_training(
-                rule_latent_inputs, all_train_inputs, num_train
-            )
-
-            # Calculate training loss for all tasks - vectorized
+            # Calculate training loss for all tasks
             batch_training_loss = 0.0
             batch_holdout_loss = 0.0
 
             # Process all tasks at once
-            for i in range(rule_latent_inputs.size(0)):
-                num_train_i = num_train[i].item()
-                if num_train_i > 0:
-                    # Get training targets for this task
-                    train_logits = outputs["training_logits"][
-                        i, :num_train_i
-                    ]  # [num_train, 10, 30, 30]
-                    train_outputs = all_train_outputs[
-                        i, :num_train_i
-                    ]  # [num_train, 1, 30, 30]
+            for i in range(batch_size):
+                # Get rule latent for this task
+                rule_latent = rule_latents[i : i + 1]  # [1, 128]
 
-                    # Calculate loss for this task
-                    task_loss, components = calculate_classification_loss(
-                        train_logits, train_outputs, self.config
-                    )
-                    batch_training_loss += task_loss
+                # 1. Test example prediction (main target)
+                test_logits = self.model.decoder(
+                    rule_latent, test_inputs[i : i + 1]
+                )  # [1, 10, 30, 30]
+                test_loss, test_comp = calculate_classification_loss(
+                    test_logits, test_outputs[i : i + 1], self.config
+                )
+                batch_training_loss += test_loss
 
-                    # Update metrics
-                    for key, value in components.items():
-                        if key != "total_loss":
-                            loss_components[key] += value
+                # Update test metrics
+                for key, value in test_comp.items():
+                    if key != "total_loss":
+                        loss_components[key] += value
 
-                # Calculate holdout loss (if available)
+                # 2. Rule latent example 1 prediction (to prevent memorization)
+                # Use raw targets from batch (ARC format)
+                ex1_input = raw_rule_latent_targets[i][0]["input"].unsqueeze(
+                    0
+                )  # [1, 1, 30, 30]
+                ex1_output = raw_rule_latent_targets[i][0]["output"].unsqueeze(
+                    0
+                )  # [1, 1, 30, 30]
+
+                ex1_logits = self.model.decoder(
+                    rule_latent, ex1_input
+                )  # [1, 10, 30, 30]
+                ex1_loss, ex1_comp = calculate_classification_loss(
+                    ex1_logits, ex1_output, self.config
+                )
+                batch_training_loss += ex1_loss
+                for key, value in ex1_comp.items():
+                    if key != "total_loss":
+                        loss_components[key] += value
+
+                # 3. Rule latent example 2 prediction (to prevent memorization)
+                ex2_input = raw_rule_latent_targets[i][1]["input"].unsqueeze(
+                    0
+                )  # [1, 1, 30, 30]
+                ex2_output = raw_rule_latent_targets[i][1]["output"].unsqueeze(
+                    0
+                )  # [1, 1, 30, 30]
+
+                ex2_logits = self.model.decoder(
+                    rule_latent, ex2_input
+                )  # [1, 10, 30, 30]
+                ex2_loss, ex2_comp = calculate_classification_loss(
+                    ex2_logits, ex2_output, self.config
+                )
+                batch_training_loss += ex2_loss
+                for key, value in ex2_comp.items():
+                    if key != "total_loss":
+                        loss_components[key] += value
+
+                # Calculate holdout loss (if available) - for validation only
                 if has_holdout[i]:
                     holdout_logits = self.model.decoder(
-                        outputs["rule_latents"][i : i + 1], holdout_inputs[i : i + 1]
+                        rule_latent, holdout_inputs[i : i + 1]
                     )
                     holdout_loss, holdout_comp = calculate_classification_loss(
                         holdout_logits, holdout_outputs[i : i + 1], self.config

--- a/algo/training/trainer.py
+++ b/algo/training/trainer.py
@@ -194,12 +194,8 @@ class ARCTrainer:
 
                 # 2. Rule latent example 1 prediction (to prevent memorization)
                 # Use raw targets from batch (ARC format)
-                ex1_input = raw_rule_latent_targets[i][0]["input"].unsqueeze(
-                    0
-                )  # [1, 1, 30, 30]
-                ex1_output = raw_rule_latent_targets[i][0]["output"].unsqueeze(
-                    0
-                )  # [1, 1, 30, 30]
+                ex1_input = raw_rule_latent_targets[i][0]["input"]  # [1, 1, 30, 30]
+                ex1_output = raw_rule_latent_targets[i][0]["output"]  # [1, 1, 30, 30]
 
                 ex1_logits = self.model.decoder(
                     rule_latent, ex1_input
@@ -213,12 +209,8 @@ class ARCTrainer:
                         loss_components[key] += value
 
                 # 3. Rule latent example 2 prediction (to prevent memorization)
-                ex2_input = raw_rule_latent_targets[i][1]["input"].unsqueeze(
-                    0
-                )  # [1, 1, 30, 30]
-                ex2_output = raw_rule_latent_targets[i][1]["output"].unsqueeze(
-                    0
-                )  # [1, 1, 30, 30]
+                ex2_input = raw_rule_latent_targets[i][1]["input"]  # [1, 1, 30, 30]
+                ex2_output = raw_rule_latent_targets[i][1]["output"]  # [1, 1, 30, 30]
 
                 ex2_logits = self.model.decoder(
                     rule_latent, ex2_input

--- a/scripts/overfit_experiment.py
+++ b/scripts/overfit_experiment.py
@@ -155,7 +155,7 @@ class OverfitExperiment:
         model = SimpleARCModel(self.config)
 
         # create trainer with overfitting config
-        trainer = ARCTrainer(model, self.config)
+        trainer = ARCTrainer(model, self.config, task_dataset)
 
         # override config for overfitting
         trainer.config.num_epochs = epochs

--- a/scripts/view_model_predictions.py
+++ b/scripts/view_model_predictions.py
@@ -39,9 +39,9 @@ def extract_sample_from_batch(batch, sample_idx, evaluation_mode="test"):
         },
     }
 
-    # Use holdout data if in holdout mode and available
-    if evaluation_mode == "holdout" and batch["has_holdout"][sample_idx]:
-        sample["test_example"] = {
+    # Add holdout data if available
+    if batch["has_holdout"][sample_idx]:
+        sample["holdout_example"] = {
             "input": batch["holdout_inputs"][sample_idx],
             "output": batch["holdout_outputs"][sample_idx],
         }
@@ -364,6 +364,13 @@ def evaluate_model_on_tasks(
                     },
                 }
 
+                # Add holdout data if available
+                if holdout_example is not None:
+                    sample_data["holdout_example"] = {
+                        "input": tensor_to_grayscale_numpy(holdout_example["input"]),
+                        "output": tensor_to_grayscale_numpy(holdout_example["output"]),
+                    }
+
                 task_results.append(
                     {
                         "combination_idx": combo_idx,
@@ -567,6 +574,13 @@ def test_all_combinations(
                         "output": tensor_to_grayscale_numpy(test_example["output"]),
                     },
                 }
+
+                # Add holdout data if available
+                if holdout_example is not None:
+                    sample_data["holdout_example"] = {
+                        "input": tensor_to_grayscale_numpy(holdout_example["input"]),
+                        "output": tensor_to_grayscale_numpy(holdout_example["output"]),
+                    }
 
                 task_results.append(
                     {
@@ -1025,7 +1039,7 @@ def main():
                 # New format - direct sample data
                 sample_data = selected_task["sample_data"]
                 fig = visualize_prediction_comparison(
-                    sample_data, selected_task["predictions"]
+                    sample_data, selected_task["predictions"], evaluation_mode
                 )
                 st.pyplot(fig)
             else:
@@ -1040,7 +1054,7 @@ def main():
                     batch, sample_idx, evaluation_mode
                 )
                 fig = visualize_prediction_comparison(
-                    sample_data, selected_task["predictions"]
+                    sample_data, selected_task["predictions"], evaluation_mode
                 )
                 st.pyplot(fig)
 
@@ -1186,7 +1200,9 @@ def main():
 
                 # visualize the selected combination
                 fig = visualize_prediction_comparison(
-                    selected_combo["sample_data"], selected_combo["predictions"]
+                    selected_combo["sample_data"],
+                    selected_combo["predictions"],
+                    evaluation_mode,
                 )
                 st.pyplot(fig)
 

--- a/scripts/view_model_predictions.py
+++ b/scripts/view_model_predictions.py
@@ -693,6 +693,7 @@ def main():
         st.stop()
 
     config.use_color_relabeling = False
+    config.enable_counterfactuals = False
     dataset = ARCDataset(
         config.arc_agi1_dir, config, holdout=True, use_first_combination_only=False
     )

--- a/scripts/visualization_utils.py
+++ b/scripts/visualization_utils.py
@@ -1,0 +1,370 @@
+#!/usr/bin/env python3
+"""
+Shared visualization and type conversion utilities for ARC-AGI dataset viewers.
+
+Common functions used by both view_dataset.py and view_model_predictions.py.
+"""
+
+import torch
+import numpy as np
+import matplotlib.pyplot as plt
+import matplotlib.patches as patches
+
+# ARC color palette (official 10 colors)
+ARC_COLORS = [
+    "#000000",  # 0: Black
+    "#0074D9",  # 1: Blue
+    "#FF4136",  # 2: Red
+    "#2ECC40",  # 3: Green
+    "#FFDC00",  # 4: Yellow
+    "#AAAAAA",  # 5: Grey
+    "#F012BE",  # 6: Fuschia
+    "#FF851B",  # 7: Orange
+    "#7FDBFF",  # 8: Teal
+    "#870C25",  # 9: Brown
+]
+
+
+def tensor_to_numpy(tensor):
+    """Convert PyTorch tensor to numpy array."""
+    # Handle numpy arrays (already converted)
+    if isinstance(tensor, np.ndarray):
+        return tensor
+
+    # Handle pytorch tensors
+    if tensor.dim() == 4:  # [B, C, H, W]
+        return tensor.squeeze(0).permute(1, 2, 0).cpu().numpy()
+    elif tensor.dim() == 3:  # [C, H, W]
+        return tensor.permute(1, 2, 0).cpu().numpy()
+    elif tensor.dim() == 2:  # [H, W]
+        return tensor.cpu().numpy()
+    else:
+        return tensor.cpu().numpy()
+
+
+def tensor_to_grayscale_numpy(tensor):
+    """Convert PyTorch tensor to grayscale numpy array."""
+    # Handle numpy arrays (already converted)
+    if isinstance(tensor, np.ndarray):
+        return tensor
+
+    # Handle pytorch tensors
+    if tensor.dim() == 4:  # [B, C, H, W]
+        return tensor.squeeze(0).squeeze(0).cpu().numpy()
+    elif tensor.dim() == 3:  # [C, H, W]
+        return tensor.squeeze(0).cpu().numpy()
+    elif tensor.dim() == 2:  # [H, W]
+        return tensor.cpu().numpy()
+    else:
+        return tensor.cpu().numpy()
+
+
+def denormalize_rgb(img_tensor):
+    """Convert normalized RGB tensor back to [0, 1] range."""
+    # Convert from [-1, 1] to [0, 1]
+    img = (img_tensor + 1) / 2
+    return torch.clamp(img, 0, 1)
+
+
+def apply_arc_color_palette(img_np):
+    """Apply ARC color palette to grayscale image."""
+    rgb_img = np.zeros((*img_np.shape, 3))
+    for i, color in enumerate(ARC_COLORS):
+        mask = img_np == i
+        rgb_img[mask] = (
+            np.array([int(color[1:3], 16), int(color[3:5], 16), int(color[5:7], 16)])
+            / 255.0
+        )
+    return rgb_img
+
+
+def visualize_arc_image(img_tensor, title, is_rgb=True, figsize=(4, 4)):
+    """Visualize an ARC image with proper color mapping."""
+    fig, ax = plt.subplots(1, 1, figsize=figsize)
+
+    if is_rgb:
+        # RGB image (example images)
+        img = denormalize_rgb(img_tensor)
+        img_np = tensor_to_numpy(img)
+        ax.imshow(img_np)
+    else:
+        # Grayscale image (target images)
+        img_np = tensor_to_grayscale_numpy(img_tensor)
+        rgb_img = apply_arc_color_palette(img_np)
+        ax.imshow(rgb_img)
+
+    ax.set_title(title, fontsize=10)
+    ax.axis("off")
+
+    # Add grid
+    ax.set_xticks(np.arange(-0.5, img_np.shape[1], 1), minor=True)
+    ax.set_yticks(np.arange(-0.5, img_np.shape[0], 1), minor=True)
+    ax.grid(which="minor", color="gray", linestyle="-", linewidth=0.5, alpha=0.3)
+
+    return fig
+
+
+def show_color_palette():
+    """Display the ARC color palette."""
+    fig, ax = plt.subplots(1, 1, figsize=(10, 2))
+
+    for i, color in enumerate(ARC_COLORS):
+        ax.add_patch(
+            patches.Rectangle((i, 0), 1, 1, facecolor=color, edgecolor="black")
+        )
+        ax.text(
+            i + 0.5,
+            0.5,
+            str(i),
+            ha="center",
+            va="center",
+            fontsize=12,
+            color="white" if i in [0, 9] else "black",
+            weight="bold",
+        )
+
+    ax.set_xlim(0, 10)
+    ax.set_ylim(0, 1)
+    ax.set_title("ARC Color Palette (0-9)", fontsize=14)
+    ax.set_xticks(range(11))
+    ax.set_yticks([])
+    ax.set_xlabel("Color Index")
+
+    return fig
+
+
+def visualize_task_combination(
+    task_data, task_idx=0, combination_idx=0, show_holdout=False
+):
+    """Visualize a single task combination."""
+    # determine grid size based on whether we have holdout data
+    is_counterfactual = task_data.get("combination_info", {}).get(
+        "is_counterfactual", False
+    )
+    # create figure - always use 2x4 grid for consistency
+    fig, axes = plt.subplots(2, 4, figsize=(16, 8))
+    fig.suptitle(
+        f"arc task {task_idx} - combination {combination_idx}{' (counterfactual)' if is_counterfactual else ''}",
+        fontsize=16,
+    )
+
+    # get rule latent inputs and test example
+    rule_latent_examples = task_data["rule_latent_examples"]
+    test_example = task_data["test_example"]
+
+    # 1. ex1 input
+    axes[0, 0].set_title("ex1 input", fontsize=12)
+    img1 = denormalize_rgb(rule_latent_examples[0]["input"])
+    img1_np = tensor_to_numpy(img1)
+    axes[0, 0].imshow(img1_np)
+    axes[0, 0].axis("off")
+
+    # 2. ex1 output (to be rotated with cf)
+    axes[0, 1].set_title("ex1 output", fontsize=12)
+    img2 = denormalize_rgb(rule_latent_examples[0]["output"])
+    img2_np = tensor_to_numpy(img2)
+    axes[0, 1].imshow(img2_np)
+    axes[0, 1].axis("off")
+
+    # 3. ex2 input
+    axes[0, 2].set_title("ex2 input", fontsize=12)
+    img3 = denormalize_rgb(rule_latent_examples[1]["input"])
+    img3_np = tensor_to_numpy(img3)
+    axes[0, 2].imshow(img3_np)
+    axes[0, 2].axis("off")
+
+    # 4. holdout input (if available)
+    if show_holdout and task_data.get("holdout_example") is not None:
+        axes[0, 3].set_title("holdout input", fontsize=12)
+        holdout_input_np = tensor_to_grayscale_numpy(
+            task_data["holdout_example"]["input"]
+        )
+        rgb_holdout_input = apply_arc_color_palette(holdout_input_np)
+        axes[0, 3].imshow(rgb_holdout_input)
+        axes[0, 3].axis("off")
+    else:
+        # Hide holdout input if not available
+        axes[0, 3].set_title("holdout input (n/a)", fontsize=12)
+        axes[0, 3].text(
+            0.5,
+            0.5,
+            "No holdout data",
+            ha="center",
+            va="center",
+            transform=axes[0, 3].transAxes,
+        )
+        axes[0, 3].axis("off")
+
+    # 5. ex2 output (to be rotated with cf) - show training target with counterfactual
+    axes[1, 0].set_title(
+        "ex2 output (cf)" if is_counterfactual else "ex2 output", fontsize=12
+    )
+    img4 = denormalize_rgb(rule_latent_examples[1]["output"])
+    img4_np = tensor_to_numpy(img4)
+    axes[1, 0].imshow(img4_np)
+    axes[1, 0].axis("off")
+
+    # 6. test input
+    axes[1, 1].set_title("test input", fontsize=12)
+    test_input_np = tensor_to_grayscale_numpy(test_example["input"])
+    rgb_test_input = apply_arc_color_palette(test_input_np)
+    axes[1, 1].imshow(rgb_test_input)
+    axes[1, 1].axis("off")
+
+    # 7. test output (to be rotated with cf)
+    axes[1, 2].set_title(
+        "test output (cf)" if is_counterfactual else "test output", fontsize=12
+    )
+    test_output_np = tensor_to_grayscale_numpy(test_example["output"])
+    rgb_test_output = apply_arc_color_palette(test_output_np)
+    axes[1, 2].imshow(rgb_test_output)
+    axes[1, 2].axis("off")
+
+    # 8. holdout output (if available)
+    if show_holdout and task_data.get("holdout_example") is not None:
+        axes[1, 3].set_title(
+            "holdout output (cf)" if is_counterfactual else "holdout output",
+            fontsize=12,
+        )
+        holdout_output_np = tensor_to_grayscale_numpy(
+            task_data["holdout_example"]["output"]
+        )
+        rgb_holdout_output = apply_arc_color_palette(holdout_output_np)
+        axes[1, 3].imshow(rgb_holdout_output)
+        axes[1, 3].axis("off")
+    else:
+        # Hide holdout output if not available
+        axes[1, 3].set_title("holdout output (n/a)", fontsize=12)
+        axes[1, 3].text(
+            0.5,
+            0.5,
+            "No holdout data",
+            ha="center",
+            va="center",
+            transform=axes[1, 3].transAxes,
+        )
+        axes[1, 3].axis("off")
+
+    # add grid to all subplots
+    for ax in axes.flat:
+        ax.set_xticks(np.arange(-0.5, 30, 1), minor=True)
+        ax.set_yticks(np.arange(-0.5, 30, 1), minor=True)
+        ax.grid(which="minor", color="gray", linestyle="-", linewidth=0.5, alpha=0.3)
+
+    plt.tight_layout()
+    return fig
+
+
+def visualize_prediction_comparison(sample, prediction):
+    """Visualize model predictions compared to ground truth."""
+    # create figure with 2x4 grid
+    fig, axes = plt.subplots(2, 4, figsize=(16, 8))
+    fig.suptitle("model prediction comparison", fontsize=16)
+
+    # example 1 - handle RGB images from rule latent inputs
+    axes[0, 0].set_title("example 1 input", fontsize=12)
+    if "train_examples" in sample and len(sample["train_examples"]) >= 1:
+        img1_np = tensor_to_numpy(sample["train_examples"][0]["input"])
+        if len(img1_np.shape) == 3 and img1_np.shape[2] == 3:
+            # RGB image - display directly
+            axes[0, 0].imshow(img1_np)
+        else:
+            # Grayscale image - apply ARC color palette
+            img1_np = tensor_to_grayscale_numpy(sample["train_examples"][0]["input"])
+            rgb_img1 = apply_arc_color_palette(img1_np)
+            axes[0, 0].imshow(rgb_img1)
+    else:
+        axes[0, 0].text(0.5, 0.5, "No data", ha="center", va="center")
+    axes[0, 0].axis("off")
+
+    axes[0, 1].set_title("example 1 output", fontsize=12)
+    if "train_examples" in sample and len(sample["train_examples"]) >= 1:
+        img2_np = tensor_to_numpy(sample["train_examples"][0]["output"])
+        if len(img2_np.shape) == 3 and img2_np.shape[2] == 3:
+            # RGB image - display directly
+            axes[0, 1].imshow(img2_np)
+        else:
+            # Grayscale image - apply ARC color palette
+            img2_np = tensor_to_grayscale_numpy(sample["train_examples"][0]["output"])
+            rgb_img2 = apply_arc_color_palette(img2_np)
+            axes[0, 1].imshow(rgb_img2)
+    else:
+        axes[0, 1].text(0.5, 0.5, "No data", ha="center", va="center")
+    axes[0, 1].axis("off")
+
+    # example 2
+    axes[0, 2].set_title("example 2 input", fontsize=12)
+    if "train_examples" in sample and len(sample["train_examples"]) >= 2:
+        img3_np = tensor_to_numpy(sample["train_examples"][1]["input"])
+        if len(img3_np.shape) == 3 and img3_np.shape[2] == 3:
+            # RGB image - display directly
+            axes[0, 2].imshow(img3_np)
+        else:
+            # Grayscale image - apply ARC color palette
+            img3_np = tensor_to_grayscale_numpy(sample["train_examples"][1]["input"])
+            rgb_img3 = apply_arc_color_palette(img3_np)
+            axes[0, 2].imshow(rgb_img3)
+    else:
+        axes[0, 2].text(0.5, 0.5, "No data", ha="center", va="center")
+    axes[0, 2].axis("off")
+
+    axes[0, 3].set_title("example 2 output", fontsize=12)
+    if "train_examples" in sample and len(sample["train_examples"]) >= 2:
+        img4_np = tensor_to_numpy(sample["train_examples"][1]["output"])
+        if len(img4_np.shape) == 3 and img4_np.shape[2] == 3:
+            # RGB image - display directly
+            axes[0, 3].imshow(img4_np)
+        else:
+            # Grayscale image - apply ARC color palette
+            img4_np = tensor_to_grayscale_numpy(sample["train_examples"][1]["output"])
+            rgb_img4 = apply_arc_color_palette(img4_np)
+            axes[0, 3].imshow(rgb_img4)
+    else:
+        axes[0, 3].text(0.5, 0.5, "No data", ha="center", va="center")
+    axes[0, 3].axis("off")
+
+    # target input - handle new data structure
+    axes[1, 0].set_title("target input", fontsize=12)
+    if "test_example" in sample and "input" in sample["test_example"]:
+        target_input_np = tensor_to_grayscale_numpy(sample["test_example"]["input"])
+        rgb_target_input = apply_arc_color_palette(target_input_np)
+        axes[1, 0].imshow(rgb_target_input)
+    else:
+        axes[1, 0].text(0.5, 0.5, "No data", ha="center", va="center")
+    axes[1, 0].axis("off")
+
+    # ground truth output
+    axes[1, 1].set_title("ground truth", fontsize=12)
+    if "test_example" in sample and "output" in sample["test_example"]:
+        target_output_np = tensor_to_grayscale_numpy(sample["test_example"]["output"])
+        rgb_target_output = apply_arc_color_palette(target_output_np)
+        axes[1, 1].imshow(rgb_target_output)
+    else:
+        axes[1, 1].text(0.5, 0.5, "No data", ha="center", va="center")
+    axes[1, 1].axis("off")
+
+    # model prediction
+    axes[1, 2].set_title("model prediction", fontsize=12)
+    pred_np = tensor_to_grayscale_numpy(prediction)
+    rgb_pred = apply_arc_color_palette(pred_np)
+    axes[1, 2].imshow(rgb_pred)
+    axes[1, 2].axis("off")
+
+    # difference visualization
+    axes[1, 3].set_title("difference", fontsize=12)
+    if "test_example" in sample and "output" in sample["test_example"]:
+        target_output_np = tensor_to_grayscale_numpy(sample["test_example"]["output"])
+        diff = np.abs(target_output_np.astype(float) - pred_np.astype(float))
+        axes[1, 3].imshow(diff, cmap="hot", vmin=0, vmax=9)
+    else:
+        axes[1, 3].text(0.5, 0.5, "No data", ha="center", va="center")
+    axes[1, 3].axis("off")
+
+    # add grid to all subplots
+    for ax in axes.flat:
+        ax.set_xticks(np.arange(-0.5, 30, 1), minor=True)
+        ax.set_yticks(np.arange(-0.5, 30, 1), minor=True)
+        ax.grid(which="minor", color="gray", linestyle="-", linewidth=0.5, alpha=0.3)
+
+    plt.tight_layout()
+    return fig


### PR DESCRIPTION
Add counterfactual examples - for each task, add a task variant that transforms the output to prevent the decoder from memorizing solutions. 

## Train Overfit Results 
<img width="1041" height="158" alt="image" src="https://github.com/user-attachments/assets/c16faee0-2624-4ee1-b1e2-035447cf3262" />

## Train Overfit Results w/ Noising the Rule Latent
<img width="1053" height="186" alt="image" src="https://github.com/user-attachments/assets/18a24b80-5a98-413a-8467-7141c5a75502" />
This shows that the rule latent is valuable - i.e. that the correct outputs depend on the right rule latent

## Train Overfit Results w/ Counterfactual Combinations
<img width="1053" height="159" alt="image" src="https://github.com/user-attachments/assets/0ba82e0e-8ec3-44a0-8776-9efc2fea0ef6" />
High accuracy on counterfactuals - we are not just memorizing the decoder output based on the target input. 

## Holdout results
<img width="1048" height="189" alt="image" src="https://github.com/user-attachments/assets/3abe6774-5857-46d2-8a5a-7708b5cd17a3" />
Holdout results are poor. Indicative that we are not learning rules, and instead memorizing outputs based on combinations of rule latents and inputs. Poor/no generalization to unseen test cases. 